### PR TITLE
Add TCL Smart TV Pro remote (via ADB)

### DIFF
--- a/codes/TCL/Smart TV Pro.xml
+++ b/codes/TCL/Smart TV Pro.xml
@@ -1,0 +1,52 @@
+<irplus>
+ <device manufacturer="TCL" model="Smart TV Pro" columns="12" format="ADB_SENDEVENT" metadata="127.0.0.1">
+  <button label="&#1045889;" labelSize="25.0" span="6">/dev/input/event0,1 113 1,0 0 0,1 113 0,0 0 0</button>
+  <button label="&#61457;" labelSize="25.0" span="6" backgroundColor="FFC84334">/dev/input/event0,1 116 1,0 0 0,1 116 0,0 0 0</button>
+  <button label="1" labelSize="25.0" span="4">/dev/input/event0,1 2 1,0 0 0,1 2 0,0 0 0</button>
+  <button label="2" labelSize="25.0" span="4">/dev/input/event0,1 3 1,0 0 0,1 3 0,0 0 0</button>
+  <button label="3" labelSize="25.0" span="4">/dev/input/event0,1 4 1,0 0 0,1 4 0,0 0 0</button>
+  <button label="4" labelSize="25.0" span="4">/dev/input/event0,1 5 1,0 0 0,1 5 0,0 0 0</button>
+  <button label="5" labelSize="25.0" span="4">/dev/input/event0,1 6 1,0 0 0,1 6 0,0 0 0</button>
+  <button label="6" labelSize="25.0" span="4">/dev/input/event0,1 7 1,0 0 0,1 7 0,0 0 0</button>
+  <button label="7" labelSize="25.0" span="4">/dev/input/event0,1 8 1,0 0 0,1 8 0,0 0 0</button>
+  <button label="8" labelSize="25.0" span="4">/dev/input/event0,1 9 1,0 0 0,1 9 0,0 0 0</button>
+  <button label="9" labelSize="25.0" span="4">/dev/input/event0,1 10 1,0 0 0,1 10 0,0 0 0</button>
+  <button label="APPS" labelSize="18.0" span="4">/dev/input/event0,1 456 1,0 0 0,1 456 0,0 0 0</button>
+  <button label="0" labelSize="25.0" span="4">/dev/input/event0,1 11 1,0 0 0,1 11 0,0 0 0</button>
+  <button label="LIST" labelSize="18.0" span="4">/dev/input/event0,1 395 1,0 0 0,1 395 0,0 0 0</button>
+  <button label="VOL+" labelSize="18.0" span="4">/dev/input/event0,1 115 1,0 0 0,1 115 0,0 0 0</button>
+  <button label="INFO" labelSize="18.0" span="4">/dev/input/event0,1 232 1,0 0 0,1 232 0,0 0 0</button>
+  <button label="P+" labelSize="18.0" span="4">/dev/input/event0,1 402 1,0 0 0,1 402 0,0 0 0</button>
+  <button label="VOL-" labelSize="18.0" span="4">/dev/input/event0,1 114 1,0 0 0,1 114 0,0 0 0</button>
+  <button label="SETTINGS" labelSize="18.0" span="4">/dev/input/event0,1 561 1,0 0 0,1 561 0,0 0 0</button>
+  <button label="P-" labelSize="18.0" span="4">/dev/input/event0,1 403 1,0 0 0,1 403 0,0 0 0</button>
+  <button label="&#61461;" labelSize="25.0" span="4" backgroundColor="FF777777">/dev/input/event0,1 102 1,0 0 0,1 102 0,0 0 0</button>
+  <button label="&#61656;" labelSize="25.0" span="4">/dev/input/event0,1 103 1,0 0 0,1 103 0,0 0 0</button>
+  <button label="&#1045340;" labelSize="25.0" span="4" backgroundColor="FF777777">/dev/input/event0,1 139 1,0 0 0,1 139 0,0 0 0</button>
+  <button label="&#61657;" labelSize="25.0" span="4">/dev/input/event0,1 105 1,0 0 0,1 105 0,0 0 0</button>
+  <button label="OK" labelSize="25.0" span="4">/dev/input/event0,1 28 1,0 0 0,1 28 0,0 0 0</button>
+  <button label="&#61658;" labelSize="25.0" span="4">/dev/input/event0,1 106 1,0 0 0,1 106 0,0 0 0</button>
+  <button label="&#1044557;" labelSize="25.0" span="4" backgroundColor="FF777777">/dev/input/event0,1 158 1,0 0 0,1 158 0,0 0 0</button>
+  <button label="&#61655;" labelSize="25.0" span="4">/dev/input/event0,1 108 1,0 0 0,1 108 0,0 0 0</button>
+  <button label="SOURCE" labelSize="18.0" span="4" backgroundColor="FF777777">/dev/input/event0,1 471 1,0 0 0,1 471 0,0 0 0</button>
+  <button label="EXIT" labelSize="18.0" span="4">/dev/input/event0,1 174 1,0 0 0,1 174 0,0 0 0</button>
+  <button label="GUIDE" labelSize="18.0" span="4">/dev/input/event0,1 365 1,0 0 0,1 365 0,0 0 0</button>
+  <button label="TEXT" labelSize="18.0" span="4">/dev/input/event0,1 388 1,0 0 0,1 388 0,0 0 0</button>
+  <button label="LANG" labelSize="18.0" span="4">/dev/input/event0,1 199 1,0 0 0,1 199 0,0 0 0</button>
+  <space multiple="4" />
+  <button label="SUBTITLE" labelSize="18.0" span="4">/dev/input/event0,1 370 1,0 0 0,1 370 0,0 0 0</button>
+  <button label="R" labelSize="25.0" span="3" fillColor="FFC84334">/dev/input/event0,1 398 1,0 0 0,1 398 0,0 0 0</button>
+  <button label="G" labelSize="25.0" span="3" fillColor="FF1E7854">/dev/input/event0,1 399 1,0 0 0,1 399 0,0 0 0</button>
+  <button label="Y" labelSize="25.0" span="3" fillColor="FFD6A81F">/dev/input/event0,1 400 1,0 0 0,1 400 0,0 0 0</button>
+  <button label="B" labelSize="25.0" span="3" fillColor="FF2A4C94">/dev/input/event0,1 401 1,0 0 0,1 401 0,0 0 0</button>
+  <button label="&#61514;" labelSize="25.0" span="4">/dev/input/event0,1 579 1,0 0 0,1 579 0,0 0 0</button>
+  <button label="&#61516;" labelSize="25.0" span="4">/dev/input/event0,1 201 1,0 0 0,1 201 0,0 0 0</button>
+  <button label="&#61518;" labelSize="25.0" span="4">/dev/input/event0,1 577 1,0 0 0,1 577 0,0 0 0</button>
+  <button label="ZOOM" labelSize="18.0" span="4">/dev/input/event0,1 372 1,0 0 0,1 372 0,0 0 0</button>
+  <button label="&#61515;" labelSize="25.0" span="4">/dev/input/event0,1 575 1,0 0 0,1 575 0,0 0 0</button>
+  <button label="&#61517;" labelSize="25.0" span="4">/dev/input/event0,1 578 1,0 0 0,1 578 0,0 0 0</button>
+  <button label="Set TCL TV IP" labelSize="12.0" span="12">SET_METADATA</button>
+  <button label="Reconnect ADB" labelSize="12.0" span="12">RECONNECT_ADB</button>
+  <button label="Reset ADB" labelSize="12.0" span="12">RESET_ADB</button>
+ </device>
+</irplus>


### PR DESCRIPTION
Add the TCL Smart TV Pro remote (via ADB) used by TCL 55C725 and many other Android TCL TVs.

I'm not sure if it's possible to make the GUIDE button use two rows so I just left an empty space below it.

This is how it looks in irplus: 
![TCL - Smart TV Pro](https://user-images.githubusercontent.com/40729975/189536524-0d91fe83-9d00-488a-a4a8-d0d0bba57aa7.png)

And this is how the remote looks:
![TCL - Smart TV Pro](https://user-images.githubusercontent.com/40729975/189536382-f7b980bc-c11f-42c8-bd3d-79c18371e3b7.png)